### PR TITLE
fix/PRSDM-2831-filepath-sort

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -11,20 +11,21 @@ var outputDir string
 var referenceURL string
 var apiName string
 var titleFormat string
+var sortFilePath bool
 
 var convertCmd = &cobra.Command{
 	Use:   "convert",
 	Short: "Converts an OpenAPI 3 spec to markdown",
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Info("Converting to markdown...")
-		markdownService, err := markdown.NewMarkdownService(referenceURL, apiName)
+		markdownService, err := markdown.NewMarkdownService(referenceURL, apiName, sortFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		methodTitle := titleFormat == "methodUrl"
 		err = markdownService.ConvertToMarkdown(file, outputDir, methodTitle)
-		
+
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -40,6 +41,7 @@ func init() {
 	convertCmd.Flags().StringVarP(&referenceURL, "referenceURL", "r", "reference", "The reference URL")
 	convertCmd.Flags().StringVarP(&apiName, "apiName", "n", "", "The name under which the generated docs will be grouped")
 	convertCmd.Flags().StringVarP(&titleFormat, "titleFormat", "t", "", "The template format used to create the title for each operation. \nValid options are: \n\t- operationId: (Default) Uses the value of the operationId field.\n\t- MethodURL: Uses a combination of the Method property and the URL.")
+	convertCmd.Flags().BoolVarP(&sortFilePath, "sortFilePath", "s", false, "Sort by filepath by prefixing a weight to the filename. Default is to use front matter weight")
 
 	// Required flags
 	_ = convertCmd.MarkFlagRequired("file")

--- a/pkg/markdown/utils.go
+++ b/pkg/markdown/utils.go
@@ -1,0 +1,17 @@
+package markdown
+
+import "fmt"
+
+// GetWeightedFilename prefixes the filename with a digit
+func GetWeightedFilename(weight int, filename string) string {
+	var wFilename string
+
+	// Ensure number of digits is consistent for smaller numbers
+	if weight < 10 {
+		wFilename = fmt.Sprintf("0%v-%v", weight, filename)
+	} else {
+		wFilename = fmt.Sprintf("%v-%v", weight, filename)
+	}
+
+	return wFilename
+}


### PR DESCRIPTION
Added a flag to move the weight to the filename as a prefix in order to accommodate projects that sortByFilePath