### PR TITLE
fix: updated goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod tidy
@@ -41,4 +42,4 @@ brews:
     repository:
       owner: spandigital
       name: homebrew-tap
-    folder: Formula
+    directory: Formula


### PR DESCRIPTION
<!-- PROJ-123: Short description of change -->

### Description
<!-- A longer description of the change -->
The goreleaser config is no longer valid, updated to version 2

Current error
```
curl -sfL https://git.io/goreleaser | sh -s -- check
  • only  version: 2  configuration files are supported, yours is  version: 0 , please update your configuration
  ⨯ command failed                                   error=only  version: 2  configuration files are supported, yours is  version: 0 , please update your configuration
```


### Issue
<!-- JIRA link -->

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [ ] Is the documentation updated for this change?
