### PR TITLE
fix: updated goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ archives:
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
<!-- PROJ-123: Short description of change -->

### Description
<!-- A longer description of the change -->
`snapshot.name_template` property in goreleaser config has been deprecated and needs to be renamed.

### Issue
<!-- JIRA link -->

### Screenshots
<!-- If relevant -->

### Checklist before merging

* [ ] Is the documentation updated for this change?
